### PR TITLE
Remove alter param from database sync

### DIFF
--- a/deployment/docker/.env.example
+++ b/deployment/docker/.env.example
@@ -27,6 +27,7 @@ MAX_SINGLE_TORRENT_CONNECTIONS=10
 TORRENT_TIMEOUT=30000
 UDP_TRACKERS_ENABLED=true
 CONSUMER_REPLICAS=3
+AUTO_CREATE_AND_APPLY_MIGRATIONS=false # Fix for #66 - toggle on for development
 
 # Producer
 RabbitMqConfiguration__Host=rabbitmq

--- a/src/node/consumer/src/lib/config.js
+++ b/src/node/consumer/src/lib/config.js
@@ -24,7 +24,7 @@ export const databaseConfig = {
     POSTGRES_DATABASE: process.env.POSTGRES_DATABASE || 'knightcrawler',
     POSTGRES_USERNAME: process.env.POSTGRES_USERNAME || 'postgres',
     POSTGRES_PASSWORD: process.env.POSTGRES_PASSWORD || 'postgres',
-    ENABLE_SYNC: true
+    AUTO_CREATE_AND_APPLY_MIGRATIONS: parseBool(process.env.AUTO_CREATE_AND_APPLY_MIGRATIONS, false)
 }
 
 // Combine the environment variables into a connection string

--- a/src/node/consumer/src/lib/repository.js
+++ b/src/node/consumer/src/lib/repository.js
@@ -1,7 +1,7 @@
 import moment from 'moment';
 import { Sequelize, Op, DataTypes, fn, col, literal } from 'sequelize';
 import { databaseConfig } from './config.js';
-import {logger} from "./logger.js";
+import { logger } from "./logger.js";
 import * as Promises from './promises.js';
 
 const database = new Sequelize(
@@ -185,9 +185,9 @@ Subtitle.belongsTo(File, { foreignKey: 'fileId', constraints: false });
 
 export function connect() {
     if (databaseConfig.ENABLE_SYNC) {
-        return database.sync({ alter: true })
+        return database.sync()
             .catch(error => {
-                console.error('Failed syncing database: ', error);
+                console.error('Failed syncing database: ', error.message);
                 throw error;
             });
     }

--- a/src/node/consumer/src/lib/repository.js
+++ b/src/node/consumer/src/lib/repository.js
@@ -184,14 +184,15 @@ File.hasMany(Subtitle, { foreignKey: 'fileId', constraints: false });
 Subtitle.belongsTo(File, { foreignKey: 'fileId', constraints: false });
 
 export function connect() {
-    if (databaseConfig.ENABLE_SYNC) {
-        return database.sync()
-            .catch(error => {
-                console.error('Failed syncing database: ', error.message);
-                throw error;
-            });
-    }
-    return Promise.resolve();
+    return database.sync({ alter: databaseConfig.AUTO_CREATE_AND_APPLY_MIGRATIONS })
+        .catch(error => {
+            console.error('Failed syncing database: ', error.message);
+            throw error;
+        });
+    // I'm not convinced this code is needed. If anyone can see where it leads, or what it does, please inform me.
+    // For now, I'm commenting it out. I don't think we ever reach this at the moment anyway as the previous ENABLE_SYNC
+    // was always on.
+    // return Promise.resolve();
 }
 
 export function getProvider(provider) {


### PR DESCRIPTION
Re: [sequelize docs](https://sequelize.org/docs/v6/core-concepts/model-basics/#synchronization-in-production) Alter is a bad idea in production.

Also print error message instead of sequelize error object as it's a bit verbose