### PR TITLE
Add hostname to rabbit mq container

### DIFF
--- a/deployment/docker/docker-compose.yaml
+++ b/deployment/docker/docker-compose.yaml
@@ -75,6 +75,7 @@ services:
     #   - "15692:15692"
     volumes:
       - rabbitmq:/var/lib/rabbitmq
+    hostname: ${RabbitMqConfiguration__Host}
     restart: *restart-policy
     healthcheck: *rabbitmq-health
     networks:


### PR DESCRIPTION
RabbitMQ needs a persistent hostname per https://github.com/docker-library/rabbitmq/issues/392 otherwise it starts with a random one, losing data

Closes #75 