### PR TITLE
Change SQL command to insert all movies and tv categories + skip duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,9 +190,9 @@ This can be done by running the following command:
 
 ```
 docker exec -it knightcrawler-postgres-1 psql -d knightcrawler -c "
-INSERT INTO ingested_torrents (name, source, category, info_hash, size, seeders, leechers, imdb, processed, \"createdAt\", \"updatedAt\")
+INSERT INTO ingested_torrents (name, source, category, info_hash, size, seeders, leechers, imdb, processed, "createdAt", "updatedAt")
 SELECT title, 'RARBG', cat, hash, size, NULL, NULL, imdb, false, current_timestamp, current_timestamp
-FROM items where cat='tv' OR cat='movies';"
+FROM items WHERE NOT EXISTS (SELECT info_hash FROM ingested_torrents WHERE ingested_torrents.info_hash = items.hash) AND (cat LIKE 'tv%' OR cat LIKE 'movies%');"
 ```
 
 You should get a response similar to:


### PR DESCRIPTION
The rarbg dump contains multiple movies and tv categories which are unique entries. The current insert command only grabs the categories "movies" and "tv" but not the multiple movies_*** and tv_*** categories. 

This command will also skip duplicates, so the SQL command won't error out and can be run on an existing database. Duplicate check is based on the hash of the specific torrent. 

In a recent PR this part of the command:  ```"createdAt", "updatedAt")``` was changed for `` \"createdAt\", \"updatedAt\") ``.
For me this new command will error out on this change, but maybe it works for others. In this PR I've reverted this change since that has been working before.