### PR TITLE
Fix addon collection name

### DIFF
--- a/src/node/addon/src/lib/config.js
+++ b/src/node/addon/src/lib/config.js
@@ -4,7 +4,7 @@ export const cacheConfig = {
     MONGODB_DB: process.env.MONGODB_DB || 'knightcrawler',
     MONGO_INITDB_ROOT_USERNAME: process.env.MONGO_INITDB_ROOT_USERNAME || 'mongo',
     MONGO_INITDB_ROOT_PASSWORD: process.env.MONGO_INITDB_ROOT_PASSWORD || 'mongo',
-    COLLECTION_NAME: process.env.MONGODB_COLLECTION || 'knightcrawler_consumer_collection',
+    COLLECTION_NAME: process.env.MONGODB_ADDON_COLLECTION || 'knightcrawler_addon_collection',
     NO_CACHE: parseBool(process.env.NO_CACHE, false),
 }
 


### PR DESCRIPTION
Thanks @purple-emily for finding this.. 

This fixes a bug condition under which the consumer and the addon both try to use the same mongodb collection.

In "production", I was noticing addons would start to error / timeout when I had > 6 consumers running.

Post-change, I'm running 45 consumers with no timeouts :)