### PR TITLE
Resolve "pgrep: not found" issue

### DIFF
--- a/src/node/consumer/Dockerfile
+++ b/src/node/consumer/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:lts-buster-slim as builder
 
-RUN apt update && apt install -y git && rm -rf /var/lib/apt/lists/*
+RUN apt update && apt install -y git procps && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 


### PR DESCRIPTION
Resolve "pgrep: not found" issue

Added installation of the procps package in the builder stage to ensure the pgrep command is available in the final Docker image. This resolves the "pgrep: not found" issue in the HEALTHCHECK.