### PR TITLE
pgrep command is part of the procps package, installed in the builder stage, but it's not present in the final stage.

### DIFF
--- a/src/node/consumer/Dockerfile
+++ b/src/node/consumer/Dockerfile
@@ -13,7 +13,7 @@ RUN npm prune --omit=dev
 FROM node:lts-buster-slim
 
 # Install necessary packages, including procps
-RUN apt update && apt install -y procps && rm -rf /var/lib/apt/lists/*
+RUN apt update && apt install -y git procps && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/src/node/consumer/Dockerfile
+++ b/src/node/consumer/Dockerfile
@@ -12,6 +12,9 @@ RUN npm prune --omit=dev
 
 FROM node:lts-buster-slim
 
+# Install necessary packages, including procps
+RUN apt update && apt install -y procps && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY --from=builder /app ./


### PR DESCRIPTION
This modification adds the installation of procps in the final stage, ensuring that the pgrep command is available for health check. My bad to oversee this the first time around. Sorry!