### PR TITLE
Ensure we throw

### DIFF
--- a/src/producer/Features/Crawlers/Torrentio/TorrentioCrawler.cs
+++ b/src/producer/Features/Crawlers/Torrentio/TorrentioCrawler.cs
@@ -155,8 +155,7 @@ public partial class TorrentioCrawler(
 
         if (!response.IsSuccessStatusCode)
         {
-            logger.LogError("Failed to fetch {Url}", requestUrl);
-            return null;
+            throw new("Failed to fetch " + requestUrl);
         }
         
         var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());


### PR DESCRIPTION
when torrentio/knightcrawler instances return invalid status codes on fetch requests for json payloads, pre-parsing of json, polly will catch in the policy wrapped resiliency handler
