### PR TITLE
Move workflow processing to base, and then one for each docker image

### DIFF
--- a/.github/workflows/base_image_workflow.yaml
+++ b/.github/workflows/base_image_workflow.yaml
@@ -1,7 +1,14 @@
-name: Build and Push Docker Images
+name: Build and Push Docker Images Base Workflow
 
 on:
-  push:
+  workflow_call:
+    inputs:
+      CONTEXT:
+        required: true
+        type: string
+      IMAGE_NAME:
+        required: true
+        type: string
 
 jobs:
   build-and-push-images:
@@ -17,20 +24,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - context: ./src/node/addon/
-            image_name: knightcrawler-addon
-            platforms: linux/amd64,linux/arm64
-          - context: ./src/node/addon-jackett/
-            image_name: knightcrawler-addon-jackett
-            platforms: linux/amd64,linux/arm64
-          - context: ./src/node/consumer/
-            image_name: knightcrawler-consumer
-            platforms: linux/amd64,linux/arm64
-          - context: ./src/producer/
-            image_name: knightcrawler-producer
-            platforms: linux/amd64,linux/arm64
-          - context: ./src/metadata/
-            image_name: knightcrawler-metadata
+          - context: ${{ github.event.inputs.CONTEXT }}
+            image_name: ${{ github.event.inputs.IMAGE_NAME }}
             platforms: linux/amd64,linux/arm64
 
     name: Build - ${{ matrix.image_name }}

--- a/.github/workflows/build_addon.yaml
+++ b/.github/workflows/build_addon.yaml
@@ -1,0 +1,14 @@
+name: Build and Push Addon Image
+
+on:
+  push:
+    paths:
+      - 'src/node/addon/**'
+
+jobs:
+  process:
+    uses: ./.github/workflows/base_image_workflow.yaml
+    secrets: inherit
+    with:
+      CONTEXT: ./src/node/addon/
+      IMAGE_NAME: knightcrawler-addon

--- a/.github/workflows/build_consumer.yaml
+++ b/.github/workflows/build_consumer.yaml
@@ -1,0 +1,14 @@
+name: Build and Push Addon Image
+
+on:
+  push:
+    paths:
+      - 'src/node/consumer/**'
+
+jobs:
+  process:
+    uses: ./.github/workflows/base_image_workflow.yaml
+    secrets: inherit
+    with:
+      CONTEXT: ./src/node/consumer/
+      IMAGE_NAME: knightcrawler-consumer

--- a/.github/workflows/build_jackett-addon.yaml
+++ b/.github/workflows/build_jackett-addon.yaml
@@ -1,0 +1,14 @@
+name: Build and Push Addon Image
+
+on:
+  push:
+    paths:
+      - 'src/node/addon-jackett/**'
+
+jobs:
+  process:
+    uses: ./.github/workflows/base_image_workflow.yaml
+    secrets: inherit
+    with:
+      CONTEXT: ./src/node/addon-jackett/
+      IMAGE_NAME: knightcrawler-addon-jackett

--- a/.github/workflows/build_metadata.yaml
+++ b/.github/workflows/build_metadata.yaml
@@ -1,0 +1,14 @@
+name: Build and Push Addon Image
+
+on:
+  push:
+    paths:
+      - 'src/metadata/**'
+
+jobs:
+  process:
+    uses: ./.github/workflows/base_image_workflow.yaml
+    secrets: inherit
+    with:
+      CONTEXT: ./src/metadata/
+      IMAGE_NAME: knightcrawler-metadata

--- a/.github/workflows/build_producer.yaml
+++ b/.github/workflows/build_producer.yaml
@@ -1,0 +1,14 @@
+name: Build and Push Addon Image
+
+on:
+  push:
+    paths:
+      - 'src/producer/**'
+
+jobs:
+  process:
+    uses: ./.github/workflows/base_image_workflow.yaml
+    secrets: inherit
+    with:
+      CONTEXT: ./src/producer/
+      IMAGE_NAME: knightcrawler-producer


### PR DESCRIPTION
Also limits each to firing based on the path of changes in the push.